### PR TITLE
Fix JSON loading with eval

### DIFF
--- a/paradoxism/context.py
+++ b/paradoxism/context.py
@@ -38,10 +38,10 @@ xml:TypeAlias  = Union["ET.Element", "etree._Element"]
 
 
 
-model_info ={k:{v2['model']: v2 for v2 in  v}  for k,v in eval(open(os.path.join(os.path.dirname(__file__),'model_infos.json'), 'r',encoding="utf-8").read()).items()}
+model_info = {k: {v2['model']: v2 for v2 in v} for k, v in json.load(open(os.path.join(os.path.dirname(__file__), 'model_infos.json'), 'r', encoding="utf-8")).items()}
 oai={}
-if os.path.exists(os.path.join(os.path.dirname(__file__),'oai.json')):
-    oai={v['azure_deployment']: v for v in eval(open(os.path.join(os.path.dirname(__file__), 'oai.json'), encoding="utf-8").read())['azure']}
+if os.path.exists(os.path.join(os.path.dirname(__file__), 'oai.json')):
+    oai = {v['azure_deployment']: v for v in json.load(open(os.path.join(os.path.dirname(__file__), 'oai.json'), encoding="utf-8"))['azure']}
 
 def sanitize_path(path):
     """Sanitize the file or folder path, a same-format and absoluted path will return.
@@ -320,7 +320,7 @@ class _Context:
         self.executor = ThreadPoolExecutor(max_workers=8)
 
 
-        self.oai = {v['azure_deployment']: v for v in eval(open(os.path.join(split_path(__file__)[0],'oai.json'), encoding="utf-8").read())['azure']}
+        self.oai = {v['azure_deployment']: v for v in json.load(open(os.path.join(split_path(__file__)[0], 'oai.json'), encoding="utf-8"))['azure']}
         self.log_path = None
         self.paradoxism_dir = self.get_paradoxism_dir()
         self.service_type = None

--- a/paradoxism/llm/claude.py
+++ b/paradoxism/llm/claude.py
@@ -25,7 +25,7 @@ class ClaudeClient(LLMClient):
         # self.client._custom_headers['Accept-Language'] = 'zh-TW'
         # self.aclient._custom_headers['Accept-Language'] = 'zh-TW'
 
-        self.model_info = eval(open('./model_infos.json', encoding="utf-8").read())['anthropic']
+        self.model_info = json.load(open('./model_infos.json', encoding="utf-8"))['anthropic']
         if model in self.model_info:
             self.max_tokens = self.model_info[model]["max_token"]
             print(f"Model: {self.model}, Max Tokens: {self.max_tokens}")


### PR DESCRIPTION
## Summary
- replace eval when loading JSON from disk with `json.load`
- update claude client and context

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'networkx')*

------
https://chatgpt.com/codex/tasks/task_e_683c07689c308330aac846c05a601593