### PR TITLE
Remove deprecated init logging and stderr usage

### DIFF
--- a/paradoxism/__init__.py
+++ b/paradoxism/__init__.py
@@ -3,8 +3,7 @@ from __future__ import division
 from __future__ import print_function
 import sys
 import os
-from importlib import reload
-from sys import stderr
+import logging
 from typing import Union, List, Dict, Any
 # 檢查 Python 版本
 
@@ -12,12 +11,14 @@ from typing import Union, List, Dict, Any
 
 defaultencoding = 'utf-8'
 if sys.getdefaultencoding() != defaultencoding:
-    reload(sys)
-    sys.setdefaultencoding(defaultencoding)
+    logging.getLogger(__name__).debug(
+        "Expected default encoding %s but got %s", defaultencoding, sys.getdefaultencoding()
+    )
 
 PACKAGE_ROOT = os.path.dirname(__file__)
 PROJECT_ROOT = os.path.dirname(PACKAGE_ROOT)
 
 __version__ = '0.0.3'
-stderr.write('PARADOXISM {0}\n'.format(__version__))
+logger = logging.getLogger(__name__)
+logger.info('PARADOXISM %s', __version__)
 


### PR DESCRIPTION
## Summary
- clean up `paradoxism.__init__`
- remove Python 2 encoding hack and stderr printing
- log import info with standard logger

## Testing
- `pytest -q` *(fails: No module named 'networkx', ModuleNotFoundError: No module named 'paradoxism')*

------
https://chatgpt.com/codex/tasks/task_e_683c07835c208330850bf778537482d6