### PR TITLE
Update workflow to install regex

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -16,6 +16,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
+          pip install regex
           pip install .[tests]
       - name: Run tests
         run: python -m pytest


### PR DESCRIPTION
## Summary
- update GitHub Actions test workflow to install `regex`

## Testing
- `pip install -e .[tests]` *(fails: Could not find a version that satisfies the requirement)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'paradoxism')*


------
https://chatgpt.com/codex/tasks/task_e_683c0a7d31cc8330821bf85e6d9166bf